### PR TITLE
Host header and abort

### DIFF
--- a/lib/req_stream.js
+++ b/lib/req_stream.js
@@ -223,6 +223,10 @@ RequestStream.prototype.request = function () {
     // on error.
     req.once('error', this.emit.bind(this, 'error'));
 
+    // on abort, and abort call
+    req.once('abort', this.emit.bind(this, 'abort'));
+    this.abort = req.abort.bind(req)
+
     // send data if necessary.
     if (!!~['POST', 'PUT', 'PATCH'].indexOf(this.options.method) && this.options._data) {
       req.write(this.options._data);

--- a/lib/util.js
+++ b/lib/util.js
@@ -130,7 +130,11 @@ util.genOptions = function (options) {
 
   // raw uri.
   var uriEntity = URI(options.uri);
-  headers.host = uriEntity.host();
+
+  // If the host was defined manually, we leave it there
+  if (!headers.host) {
+    headers.host = uriEntity.host();
+  }
 
   if (options.data) {
     if(!!~['POST', 'PUT', 'PATCH'].indexOf(options.method)){


### PR DESCRIPTION
I found two issues (while porting from request):

  1. Abort was not exposed. So long downloads could not be aborted
  2. Manually setting the host header was overwritten.

This PR fixes those two issues.

I don't have the time to write the tests at the moment, but please let me know if you consider it a must for merge.